### PR TITLE
added newConnections to OnSubscriptionUpdateFinished signal

### DIFF
--- a/include/Qv2rayBase/Profile/ProfileManager.hpp
+++ b/include/Qv2rayBase/Profile/ProfileManager.hpp
@@ -89,7 +89,7 @@ namespace Qv2rayBase::Profile
 
       signals:
         void OnLatencyTestStarted(const ConnectionId &id);
-        void OnSubscriptionUpdateFinished(const GroupId &id);
+        void OnSubscriptionUpdateFinished(const GroupId &id, const QList<ProfileId> &newConnections);
         void OnConnectionCreated(const ProfileId &Id, const QString &displayName);
         void OnConnectionModified(const ConnectionId &id);
         void OnConnectionRenamed(const ConnectionId &Id, const QString &originalName, const QString &newName);


### PR DESCRIPTION
## Added
- New connections from the subscription are now reported as `QList<ProfileId> &` in the `OnSubscriptionUpdateFinished` signal.

## Fixed
- It seems that the signal mentioned above is never emitted, so fixed by adding `QFuture<T>::then` if it's not an async request.

## Changed
- The `if` statement `if (!isAsync)` is inverted to remove the condition negation.