### PR TITLE
[Do not merge] Fix nodes being cleared if OOCv1 update failed

### DIFF
--- a/src/Profile/ProfileManager.cpp
+++ b/src/Profile/ProfileManager.cpp
@@ -475,7 +475,11 @@ namespace Qv2rayBase::Profile
                 }
                 case Qv2rayPlugin::Subscribe_FetcherAndDecoder:
                 {
-                    return info.Creator()->FetchDecodeSubscription(subscriptionConfig.providerSettings);
+                    const auto subscriptionResult = info.Creator()->FetchDecodeSubscription(subscriptionConfig.providerSettings);
+                    if (subscriptionResult.size() > 0)
+                        return subscriptionResult;
+                    else
+                        throw std::nullopt; // Already handled by FetchDecodeSubscription
                 }
                 default: Q_UNREACHABLE(); break;
             }


### PR DESCRIPTION
**Do not merge.** It is in fact not a good idea. It is necessary for `FetchDecodeSubscription` to return some error info.